### PR TITLE
Android contest 2021. Fix bug with overlapping user account text on touch blue menu

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/DrawerLayoutAdapter.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/DrawerLayoutAdapter.java
@@ -84,7 +84,7 @@ public class DrawerLayoutAdapter extends RecyclerListView.SelectionAdapter {
         }
         MessagesController.getGlobalMainSettings().edit().putBoolean("accountsShown", accountsShown).commit();
         if (animated) {
-            itemAnimator.setShouldClipChildren(false);
+            itemAnimator.setShouldClipChildren(true);
             if (accountsShown) {
                 notifyItemRangeInserted(2, getAccountRowsCount());
             } else {


### PR DESCRIPTION
Fix bug with overlapping text on user selection menu click

Reference video:

https://user-images.githubusercontent.com/24439691/107848401-de603d00-6dfb-11eb-8865-571ec2433db6.mp4

How to reproduce:

Slightly swipe on the blue user selection menu

Device:
Samsung J5
Android 8.0.0 API LVL 26
